### PR TITLE
Updated workflow to work with new coverage configuration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,8 +51,8 @@ jobs:
       - name: Check that workflows are up to date
         run: sbt --client '++${{ matrix.scala }}; githubWorkflowCheck'
 
-      - name: Build project
-        run: sbt --client '++${{ matrix.scala }}; test'
+      - name: Test (enabled coverage)
+        run: sbt --client '++${{ matrix.scala }}; coverage test'
 
       - name: Coverage
         run: sbt --client '++${{ matrix.scala }}; coverageReport'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,8 +51,8 @@ jobs:
       - name: Check that workflows are up to date
         run: sbt --client '++${{ matrix.scala }}; githubWorkflowCheck'
 
-      - name: Test (enabled coverage)
-        run: sbt --client '++${{ matrix.scala }}; coverage test'
+      - name: Test (coverage enabled)
+        run: sbt --client '++${{ matrix.scala }}; clean; coverage; test'
 
       - name: Coverage
         run: sbt --client '++${{ matrix.scala }}; coverageReport'

--- a/README.md
+++ b/README.md
@@ -22,6 +22,16 @@ To run all the tests use the command:
 ``` shell
 sbt test
 ```
+# Coverage
+
+To verify the coverage of the application run all the tests with coverage enabled:
+``` shell
+sbt clean coverage test
+```
+Then generate the reports:
+``` shell
+sbt coverageReport
+```
 
 # Download
 Download the latest Jar file from this repository's [releases page](https://github.com/Tale152/PPS-20-pps-sq/releases).

--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,6 @@
 import Dependencies._
 
-ThisBuild / scalaVersion     := "2.12.8"
+ThisBuild / scalaVersion := "2.12.8"
 
 lazy val root = (project in file("."))
   .settings(
@@ -24,7 +24,6 @@ concurrentRestrictions in Global := Seq(Tags.limitAll(numberOfTestProcessors))
 ThisBuild / githubWorkflowPublishTargetBranches := Seq()
 
 // scoverage plugin keys
-coverageEnabled := true
 coverageMinimum := 60 //%
 coverageFailOnMinimum := true
 coverageHighlighting := true
@@ -36,6 +35,8 @@ lazy val exclusionsRegex = Seq(
 coverageExcludedPackages := exclusionsRegex
 
 // Add scoverage to the workflow
+ThisBuild / githubWorkflowBuild := Seq(WorkflowStep.Sbt(List("coverage test"), name = Some("Test (enabled coverage)")))
+
 ThisBuild / githubWorkflowBuildPostamble ++= List(
   WorkflowStep.Sbt(List("coverageReport"), name = Some("Coverage"))
 )

--- a/build.sbt
+++ b/build.sbt
@@ -35,10 +35,10 @@ lazy val exclusionsRegex = Seq(
 coverageExcludedPackages := exclusionsRegex
 
 // Add scoverage to the workflow
-ThisBuild / githubWorkflowBuild := Seq(WorkflowStep.Sbt(List("coverage test"), name = Some("Test (enabled coverage)")))
-
-ThisBuild / githubWorkflowBuildPostamble ++= List(
-  WorkflowStep.Sbt(List("coverageReport"), name = Some("Coverage"))
+ThisBuild / githubWorkflowBuild := Seq(WorkflowStep.Sbt(List("clean", "coverage", "test"),
+                                       name = Some("Test (coverage enabled)")))
+ThisBuild / githubWorkflowBuildPostamble ++= List(WorkflowStep.Sbt(List("coverageReport"),
+                                                  name = Some("Coverage"))
 )
 
 // add scalafix settings


### PR DESCRIPTION
Old coverage uses the enableCoverage := true setting in build.sbt, it can't be used anymore because the assembled jars conatins the dependency